### PR TITLE
Auto Shoot

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -13,6 +13,8 @@ $.Player = function () {
     this.TurnSpeed = 4;
     this.Velocity = new $.Point(0, 0);
     this.Moving = false;
+    this.AutoShoot = true;
+    this.ShootRange = 500;
 
     this.MaxHP = 75;
     this.HP = this.MaxHP;
@@ -105,17 +107,24 @@ $.Player.prototype.ColorFromPowerUp = function () {
 };
 
 $.Player.prototype.ShootBullet = function () {
-    var mouse = new $.Point($.MousePoint.X + $.CanvasBounds.X, $.MousePoint.Y + $.CanvasBounds.Y);
+    var aimPoint;
+    if (this.AutoShoot && this.CurrentTarget) {
+        aimPoint = this.CurrentTarget.Bounds.Centre;
+    } else {
+        aimPoint = new $.Point($.MousePoint.X + $.CanvasBounds.X, $.MousePoint.Y + $.CanvasBounds.Y);   
+    }
 
     var speed = 800;
     var size = 12;
     var ttl = 3.5;
     var shots = this.TripleShot ? 3 : 1;    
     var angle = Math.atan2(
-        mouse.Y - this.Bounds.Centre.Y,
-        mouse.X - this.Bounds.Centre.X) * 180 / Math.PI;
+        aimPoint.Y - this.Bounds.Centre.Y,
+        aimPoint.X - this.Bounds.Centre.X) * 180 / Math.PI;
     var color = this.ColorFromPowerUp();
 
+    // NOTE
+    // Shots represent the effect of multiple projectiles gained by the triple shoot power up
     for (var i = 0; i < shots; i++) {
         var aim;
         var newAngle = angle;
@@ -137,7 +146,7 @@ $.Player.prototype.ShootBullet = function () {
             direction = aim.Normalize(this.Bounds.Centre);
         }
         else {
-            direction = mouse.Normalize(this.Bounds.Centre);
+            direction = aimPoint.Normalize(this.Bounds.Centre);
         }
                 
         var x = this.Bounds.Centre.X - size / 2;
@@ -261,12 +270,13 @@ $.Player.prototype.Update = function () {
     this.UpdateAim();
     this.UpdateRotation();
     //this.UpdateDirection();
+    this.UpdateTarget();
     this.UpdateMovement();
     this.UpdateShooting();
     this.UpdatePowerUps();
-    this.CurrentAnimation.Update();
-    this.UpdateCollision();
+    this.UpdateWorldCollision();
     this.UpdateJetTrails();
+    this.CurrentAnimation.Update();
 };
 
 $.Player.prototype.UpdateCurrentTile = function () {
@@ -377,6 +387,30 @@ $.Player.prototype.UpdateDirection = function () {
     this.Velocity.Y += yMove;
 }
 
+$.Player.prototype.UpdateTarget = function () {
+    if (!this.AutoShoot) {
+        return;
+    }
+
+    // Set target that is closest and in shoot range
+    if (this.CurrentTarget == null) {
+        this.CurrentTarget = $.GameWorld.GetClosesInRangeEnemy(this.Bounds.Centre, this.ShootRange);
+    }
+
+    // Set target to null if it dies
+    if (this.CurrentTarget != null && !this.CurrentTarget.Alive) {
+        this.CurrentTarget = null;
+    }
+
+    // Set target to null if it goes out of range
+    if (this.CurrentTarget != null && this.CurrentTarget.Alive) {
+        var targetDistance = this.Bounds.Centre.DistanceBetween(this.CurrentTarget.Bounds.Centre);
+        if (targetDistance > this.ShootRange) {
+            this.CurrentTarget = null;
+        }
+    }
+}
+
 $.Player.prototype.UpdateMovement = function () {
     this.Velocity.Truncate(this.MaxVelocity);
 
@@ -387,7 +421,7 @@ $.Player.prototype.UpdateMovement = function () {
     this.Velocity.Y *= this.Deceleration;
 }
 
-$.Player.prototype.UpdateCollision = function () {
+$.Player.prototype.UpdateWorldCollision = function () {
     if (!this.Bounds.ContainsRect($.GameWorld.Map)) {
         if (this.Bounds.X < $.GameWorld.Map.X) {
             this.Bounds.X = $.GameWorld.Map.X;
@@ -405,7 +439,11 @@ $.Player.prototype.UpdateCollision = function () {
 };
 
 $.Player.prototype.UpdateShooting = function () {
-    if ($.IsMouseDown) {
+    var shootEnabled = 
+        (this.AutoShoot && this.CurrentTarget != null) ||
+        (!this.AutoShoot && $.IsMouseDown);
+
+    if (shootEnabled) {
         var bulletRate = this.RapidFire ? this.BulletRate / 1.5 : this.BulletRate;
         this.BulletTime += $.Delta;
         if (this.BulletTime >= bulletRate) {

--- a/js/world.js
+++ b/js/world.js
@@ -1205,7 +1205,12 @@ $.World.prototype.DrawHUD = function () {
                 this.CursorHeight);
         }
     } else {
-        $.Gtx3.drawImage($.CursorImage, $.MousePoint.X, $.MousePoint.Y, 25, 25);
+        $.Gtx3.drawImage(
+            $.CursorImage, 
+            $.MousePoint.X, 
+            $.MousePoint.Y, 
+            this.CursorWidth / 2, 
+            this.CursorHeight / 2);
     }
     
     $.Gtx3.restore();

--- a/js/world.js
+++ b/js/world.js
@@ -31,6 +31,9 @@ $.World = function () {
     this.PowerUpTick = 5;
     this.PowerUpTime = 0;
 
+    this.CursorWidth = 50;
+    this.CursorHeight = 50;
+
     this.SetupSoundTrack();
 };
 
@@ -449,6 +452,32 @@ $.World.prototype.EmitBulletParticles = function (bullet) {
         this.AddParticle(x, y, 'maroon', direction, ttl, speed, particleSize, particleSize, image);
     }
 };
+
+$.World.prototype.GetClosesInRangeEnemy = function (point, range) {
+    var closestDistance = null;
+    var enemyIndex = null;
+
+    for (var i = 0; i < this.Enemies.length; i++) {
+        var currentEnemy = this.Enemies[i];
+        var distance = point.DistanceBetween(currentEnemy.Bounds.Centre);
+
+        if (closestDistance == null) {
+            closestDistance = distance;
+            enemyIndex = i;
+        }
+
+        if (distance < closestDistance) {
+            closestDistance = distance;
+            enemyIndex = i;
+        }
+    }
+
+    if (enemyIndex != null && closestDistance <= range) {
+        return this.Enemies[enemyIndex]
+    }
+    
+    return null;    
+}
 
 
 // Update Functions
@@ -1165,6 +1194,19 @@ $.World.prototype.DrawHUD = function () {
 
 
     // CURSOR
-    $.Gtx3.drawImage($.CursorImage, $.MousePoint.X, $.MousePoint.Y, 25, 25);
+    if (this.Hero.AutoShoot) {
+        if (this.Hero.CurrentTarget) {
+            var aimPoint = this.Hero.CurrentTarget.Bounds.Centre;
+            $.Gtx3.drawImage(
+                $.CursorImage, 
+                aimPoint.X - $.CanvasBounds.X - this.CursorWidth / 2, 
+                aimPoint.Y - $.CanvasBounds.Y - this.CursorHeight / 2, 
+                this.CursorWidth, 
+                this.CursorHeight);
+        }
+    } else {
+        $.Gtx3.drawImage($.CursorImage, $.MousePoint.X, $.MousePoint.Y, 25, 25);
+    }
+    
     $.Gtx3.restore();
 };


### PR DESCRIPTION
# Info

The intention with this PR was to make the game easier by removing the need to manually aim and shoot with the mouse.  
This ended up making the game more fun as it puts the focus on manouvering, collecting power ups and dodging bullets.
I also found that adjusting the `ShootRange` can be use to change game feel. e.g. shorter range means you get up close with enemies thus making doging them harder and more suspensful.

## Details

A `AutoShoot` flag determines the following:
- If the closest in-range enemy is targeted
- If shooting happens automatically
- If a target is rendered on a target or where the mouse aims
Also set `AutoShoot` default to `true`

A `ShootRange` field determines the enemy proximity before bullets will fire (requires `AutoShoot` to be `true`)